### PR TITLE
Lock to @solana/web3.js 1.x for compatibility

### DIFF
--- a/layer1-chains/solana/jupiter.md
+++ b/layer1-chains/solana/jupiter.md
@@ -89,7 +89,7 @@ API DOCUMENTATION
 Running this example requires a minimum of [NodeJS 16](https://nodejs.org/en/). In your command line terminal, install the libraries.
 
 ```
-npm i @solana/web3.js
+npm i @solana/web3.js@1
 npm i cross-fetch
 npm i @project-serum/anchor
 npm i bs58

--- a/reference/alchemy-api.md
+++ b/reference/alchemy-api.md
@@ -31,7 +31,7 @@ Run the following command to install the Solana Web3.js library with npm or yarn
 npmyarn
 
 ```
-npm install --save @solana/web3.js
+npm install --save @solana/web3.js@1
 ```
 
 ### 4. Make your first request


### PR DESCRIPTION

Read why, here: https://github.com/solana-labs/solana-web3.js/issues/3498